### PR TITLE
dataarray.py do not infer dims from coords_dict in same length case

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -127,9 +127,7 @@ def _infer_coords_and_dims(
         dims = [f"dim_{n}" for n in range(len(shape))]
         if coords is not None and len(coords) == len(shape):
             # try to infer dimensions from coords
-            if utils.is_dict_like(coords):
-                dims = list(coords.keys())
-            else:
+            if not utils.is_dict_like(coords):
                 for n, (dim, coord) in enumerate(zip(dims, coords)):
                     coord = as_variable(coord, name=dims[n]).to_index_variable()
                     dims[n] = coord.name


### PR DESCRIPTION
Closes https://github.com/pydata/xarray/issues/7901

Makes the following 2 constructions equivalent simplifying logic and making code more predictable.
Removed lines are also not robust given non-sorted nature of dictionary. Although it is now sorted in python, but it can be taken from other sources and dictionary order changing is unnatural in python. Even OrderedDict doesn't have simple re-ordering functionality (only efficient methods are sending to first last).
```
import xarray as xr
arr = np.ones((2, 3))
xarr = xr.DataArray(arr, coords=dict(dim_0=np.arange(2), dim_1=list('abc')))
xarr = xr.DataArray(arr, coords=dict(dim_1=list('abc'), dim_0=np.arange(2)))
```